### PR TITLE
Encode integers to use the minimum number of bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG for SNMP Manager For ESP8266/ESP32/Arduino
 
+## 1.1.11
+
+- Fixed implementation of encoding integers to use the minimum number of bytes necessary. Previously was always used 4 bytes. This Fixes #25.
+
 ## 1.1.10
 
-- Fixed spelling error `Guage` now corrected all references to `Gauge`. This maybe a breaking change if for example you are were using `addGuageHandler` or referencing the type `GUAGG32`, which now should be updated to `addGaugeHandler` and `GAUGG32`.
+- Fixed spelling error `Guage` now corrected all references to `Gauge`. This maybe a breaking change if for example you are were using `addGuageHandler` or referencing the type `GUAGE32`, which now should be updated to `addGaugeHandler` and `GAUGE32`.
 
 ## 1.1.9
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "SNMP Manager",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "An SNMP Manager library to make SNMP requests to other SNMP enabled devices. Supporting SNMP v1 and v2, SNMP requests can be sent (GetRequest) and their responses received (GetResponse) for various SNMP data types.",
   "repository": {
     "type": "git",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SNMP Manager
-version=1.1.10
+version=1.1.11
 author=Martin Rowan <martin@martinrowan.co.uk>
 maintainer=Martin Rowan <martin@martinrowan.co.uk>
 sentence=An SNMP Manager library to make SNMP requests to other SNMP enabled devices.

--- a/src/BER.h
+++ b/src/BER.h
@@ -125,7 +125,13 @@ public:
         *ptr = _type;
         ptr++;
         unsigned char *lengthPtr = ptr++;
-        if (_value != 0)
+        // For values < 128 we use a single byte for the value
+        if (_value != 0 && _value < 0x80)
+        {
+            _length = 1;
+            *ptr++ = _value;
+        }
+        else if (_value != 0 && _value >= 0x80)
         {
             _length = 4; // FIXME: need to give this dynamic length
                          //        while(_length > 1){

--- a/src/BER.h
+++ b/src/BER.h
@@ -125,27 +125,30 @@ public:
         *ptr = _type;
         ptr++;
         unsigned char *lengthPtr = ptr++;
-        // For values < 128 we use a single byte for the value
-        if (_value != 0 && _value < 0x80)
+
+        // // For values <= 127 we use a single byte for the value
+        if (_value != 0 && _value <= 0x7F)
         {
             _length = 1;
             *ptr++ = _value;
         }
         else if (_value != 0 && _value >= 0x80)
         {
-            _length = 4; // FIXME: need to give this dynamic length
-                         //        while(_length > 1){
-                         //            if(_value >> 24 == 0){
-                         //                _length--;
-                         //                _value = _value << 8;
-                         //            } else {
-                         //                break;
-                         //            }
-                         //        }
-            *ptr++ = _value >> 24 & 0xFF;
-            *ptr++ = _value >> 16 & 0xFF;
-            *ptr++ = _value >> 8 & 0xFF;
-            *ptr++ = _value & 0xFF;
+            // Determine the number of bytes required for encoding
+            uint32_t temp = _value;
+            _length = 0;
+            while (temp > 0) {
+                temp >>= 8;
+                _length++;
+            }
+            // Multi-byte encoding
+            *ptr++ = 0x80 | _length;  // Tag for multi-byte encoding
+
+            for (size_t i = 1; i <= _length; i++) {
+                *ptr++ = _value & 0xFF;  // Store the least significant byte
+                _value >>= 8;
+            }
+            _length++;
         }
         else
         {

--- a/src/SNMPGet.h
+++ b/src/SNMPGet.h
@@ -87,6 +87,12 @@ public:
     Serial.print(ip);
     Serial.print(F(":"));
     Serial.println(port);
+		Serial.print("[DEBUG_] composed packet: ");
+    for (int i = 0; i < length; i++)
+    {
+        Serial.printf("%02x ", _packetBuffer[i]);
+    }
+    Serial.println();
 #endif
 		_udp->beginPacket(ip, port);
 		_udp->write(_packetBuffer, length);


### PR DESCRIPTION
Fixes #25 
BER/ASN.1 encoding should not include leading zero and should use the least number of bytes.