### PR TITLE
Bug fix for stackoverflow when using OIDs with 10-digit segments

### DIFF
--- a/src/BER.h
+++ b/src/BER.h
@@ -318,8 +318,8 @@ public:
                 end = strchr(start, 0);
                 toBreak = true;
             }
-            char tempBuf[10];
-            memset(tempBuf, 0, 10);
+            char tempBuf[12];
+            memset(tempBuf, 0, 12);
             //            char* tempBuf = (char*) malloc(sizeof(char) * (end-start));
             strncpy(tempBuf, start, end - start + 1);
             long tempVal;

--- a/src/BER.h
+++ b/src/BER.h
@@ -323,7 +323,8 @@ public:
             //            char* tempBuf = (char*) malloc(sizeof(char) * (end-start));
             strncpy(tempBuf, start, end - start + 1);
             long tempVal;
-            tempVal = atoi(tempBuf);
+            char *pEnd;
+            tempVal = (uint32_t)strtoul(tempBuf, &pEnd, 10);
             if (tempVal < 128)
             {
                 _length += 1;


### PR DESCRIPTION
Bug Statement:
Please consider this usecase from a real-life project
`const char *oidIfSpeedGauge = ".1.3.6.1.2.1.10.94.1.1.4.1.2.2183538601"; 
`
When processing (serialising) the segment "2183538601", a stack overflow happens due to the temp buffer being exactly 10 bytes.
After increasing the buffer, atoi() produces a wrong output. Using strtoul() solves this problem.


commits:
- **Increased buffer size to 12 (must be 11 or more) to avoid stack overflow with handling 10-digit strings**
- **Replaced atoi() with strtoul() to convert to unsigned numbers (atoi gives interger numbers and this leads to wrong conversion with 10-digit strings)**
